### PR TITLE
Expand allowed commands and fix Oh My Zsh updates

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -5,9 +5,9 @@ Present the user with a formatted list of all software, organized by category (C
 Ask the user which ones they would like to update. They can select multiple items.
 
 Once they confirm their selection, update the selected software using the appropriate method:
-- For "all": `brew update && brew upgrade && brew cleanup` then `omz update`
+- For "all": `brew update && brew upgrade && brew cleanup` then update Oh My Zsh
 - For Homebrew packages/casks: `brew upgrade <package>`
-- For Oh My Zsh: `omz update`
+- For Oh My Zsh: `ZSH="${ZSH:-$HOME/.oh-my-zsh}" && "$ZSH/tools/upgrade.sh"` (use the direct upgrade script since `omz update` doesn't work in non-interactive shells)
 
 If $ARGUMENTS is provided, treat it as the software selection and skip the prompting step.
 

--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,3 @@
-# Taps
-tap "homebrew/cask-fonts"
-
 # CLI Tools
 brew "git"
 brew "zsh"
@@ -19,6 +16,7 @@ cask "rapidapi"
 cask "proxyman"
 cask "claude"
 cask "db-browser-for-sqlite"
+cask "ssh-config-editor"
 
 # Fonts
 cask "font-jetbrains-mono"

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,7 @@
 # CLI Tools
 brew "git"
+brew "gh"
+brew "glab"
 brew "zsh"
 brew "swift-format"
 brew "swiftlint"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,19 +61,45 @@ Commands read from `~/.Brewfile` to determine available software.
 
 ## Allowed Commands
 
+These commands should run without requiring user approval:
+
 ```
+# Homebrew - all variations
 brew install:*
+brew install --cask:*
 brew uninstall:*
+brew uninstall --cask:*
+brew reinstall:*
+brew reinstall --cask:*
 brew bundle:*
 brew update
+brew upgrade
 brew upgrade:*
 brew cleanup
-omz update
+brew list
+brew list --cask
+brew info:*
+brew search:*
+brew tap:*
+brew untap:*
+
+# Oh My Zsh
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)":*
+$ZSH/tools/upgrade.sh
+"$ZSH/tools/upgrade.sh"
+
+# Xcode management
 xcodes install:*
 xcodes uninstall:*
 xcodes installed
 xcodes list
 xcodes select:*
+xcodes version
+xcodes update
+
+# File operations for config installation
+cp:*
+mkdir:*
 ```
 
-When running the `/install`, `/update`, or `/uninstall` commands, do not ask for permission to run brew commands. Only ask for confirmation if the user chooses to uninstall all software.
+When running the `/install`, `/update`, or `/uninstall` commands, execute all commands immediately without asking for permission. Only ask for confirmation if the user chooses to uninstall all software.

--- a/oh_my_zsh_install.sh
+++ b/oh_my_zsh_install.sh
@@ -5,7 +5,8 @@ echo "\nInstalling oh-my-zsh..."
 
 ## Check if Oh My Zsh is already installed
 if [ -d "$HOME/.oh-my-zsh" ]; then
-    echo "Oh My Zsh is already installed. Skipping..."
+    echo "Oh My Zsh is already installed. Updating..."
+    "$HOME/.oh-my-zsh/tools/upgrade.sh"
 else
     ## Use --unattended to prevent spawning a new shell
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended


### PR DESCRIPTION
## Summary
- Expanded the allowed commands list in CLAUDE.md to include all Homebrew variations, Oh My Zsh scripts, xcodes commands, and file operations for config installation
- Fixed Oh My Zsh update command to use direct upgrade script (`$ZSH/tools/upgrade.sh`) since `omz update` doesn't work in non-interactive shells
- Updated `oh_my_zsh_install.sh` to run upgrade if Oh My Zsh is already installed
- Added `ssh-config-editor` to Brewfile
- Removed deprecated `homebrew/cask-fonts` tap (no longer needed)

## Test plan
- [ ] Run `/install` and verify no permission prompts appear for brew commands
- [ ] Run `/update all` and verify Oh My Zsh updates correctly
- [ ] Run full `mac_setup.sh` on a fresh system to verify idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)