### PR TITLE
Add dedicated Claude config setup script

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(brew install:*)",
+      "Bash(brew install --cask:*)",
+      "Bash(brew uninstall:*)",
+      "Bash(brew uninstall --cask:*)",
+      "Bash(brew reinstall:*)",
+      "Bash(brew reinstall --cask:*)",
+      "Bash(brew bundle:*)",
+      "Bash(brew update:*)",
+      "Bash(brew upgrade:*)",
+      "Bash(brew cleanup:*)",
+      "Bash(brew list:*)",
+      "Bash(brew info:*)",
+      "Bash(brew search:*)",
+      "Bash(brew tap:*)",
+      "Bash(brew untap:*)",
+      "Bash(xcodes install:*)",
+      "Bash(xcodes uninstall:*)",
+      "Bash(xcodes installed:*)",
+      "Bash(xcodes list:*)",
+      "Bash(xcodes select:*)",
+      "Bash(xcodes version:*)",
+      "Bash(xcodes update:*)",
+      "Bash(omz update:*)",
+      "Bash(git checkout:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "Bash(glab mr:*)",
+      "Bash(glab issue:*)",
+      "Read(~/.claude/commands/**)",
+      "Read(~/.Brewfile)"
+    ]
+  }
+}

--- a/Brewfile
+++ b/Brewfile
@@ -2,6 +2,7 @@
 brew "git"
 brew "gh"
 brew "glab"
+brew "jq"
 brew "zsh"
 brew "swift-format"
 brew "swiftlint"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,12 @@ Automates the installation and configuration of daily-use software and developme
 - `mac_setup.sh` - Main entry point that orchestrates all other scripts
 - `homebrew_install.sh` - Installs Homebrew and applications from the Brewfile
 - `Brewfile` - Declarative list of all Homebrew packages and casks (copied to `~/.Brewfile` during setup)
-- `.claude/commands/` - Claude Code commands (copied to `~/.claude/commands/` during setup)
 - `oh_my_zsh_install.sh` - Installs Oh My Zsh
 - `zshrc_alias_setup.sh` - Configures shell aliases (git shortcuts, utilities)
 - `ssh_key_setup.sh` - Sets up SSH keys
+- `claude_config_setup.sh` - Installs Claude Code commands and settings
+- `.claude/commands/` - Claude Code commands (copied to `~/.claude/commands/` during setup)
+- `.claude/settings.json` - Claude Code permission settings (merged into `~/.claude/settings.json` during setup)
 
 ## Installed Software
 

--- a/claude_config_setup.sh
+++ b/claude_config_setup.sh
@@ -1,0 +1,26 @@
+#!/bin/zsh
+
+echo "\nInstalling Claude commands and settings..."
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+## Create Claude directories
+mkdir -p ~/.claude/commands
+
+## Copy Claude commands
+cp "$SCRIPT_DIR/.claude/commands/"*.md ~/.claude/commands/
+echo "Claude commands installed to ~/.claude/commands/"
+
+## Merge settings.json (idempotent - adds new permissions without overwriting existing)
+if [ -f ~/.claude/settings.json ]; then
+    jq --slurpfile new "$SCRIPT_DIR/.claude/settings.json" \
+        '. * $new[0] | .permissions.allow = ([.permissions.allow // []] + [$new[0].permissions.allow // []] | add | unique)' \
+        ~/.claude/settings.json > ~/.claude/settings.json.tmp \
+        && mv ~/.claude/settings.json.tmp ~/.claude/settings.json
+    echo "Claude settings merged into ~/.claude/settings.json"
+else
+    cp "$SCRIPT_DIR/.claude/settings.json" ~/.claude/settings.json
+    echo "Claude settings installed to ~/.claude/settings.json"
+fi
+
+echo "\nDone."

--- a/homebrew_install.sh
+++ b/homebrew_install.sh
@@ -26,12 +26,6 @@ brew bundle --file=~/.Brewfile
 
 echo "\ndone."
 
-## Copy Claude commands to home directory
-echo "\nInstalling Claude commands..."
-mkdir -p ~/.claude/commands
-cp "$SCRIPT_DIR/.claude/commands/"*.md ~/.claude/commands/
-echo "Claude commands installed to ~/.claude/commands/"
-
 # Ensure .zshrc exists
 touch ~/.zshrc
 

--- a/mac_setup.sh
+++ b/mac_setup.sh
@@ -6,9 +6,11 @@ chmod 0700 oh_my_zsh_install.sh
 chmod 0700 homebrew_install.sh
 chmod 0700 zshrc_alias_setup.sh
 chmod 0700 ssh_key_setup.sh
+chmod 0700 claude_config_setup.sh
 
 sh oh_my_zsh_install.sh
 sh homebrew_install.sh
+sh claude_config_setup.sh
 sh zshrc_alias_setup.sh
 sh ssh_key_setup.sh
 


### PR DESCRIPTION
## Summary
- Created `claude_config_setup.sh` to handle Claude Code commands and settings installation
- Added `.claude/settings.json` with auto-approved permission rules for brew, xcodes, gh, glab, and git commands
- Added `jq` to Brewfile for idempotent JSON merging of settings
- Settings are merged (not overwritten) so user customizations are preserved

## Changes
- `claude_config_setup.sh` - New script for Claude config installation
- `.claude/settings.json` - Permission settings template
- `Brewfile` - Added jq
- `mac_setup.sh` - Added claude_config_setup.sh (runs after homebrew)
- `homebrew_install.sh` - Removed Claude setup code
- `CLAUDE.md` - Updated documentation

## Test plan
- [ ] Run `./claude_config_setup.sh` on a system with existing `~/.claude/settings.json`
- [ ] Run `./claude_config_setup.sh` on a system without `~/.claude/settings.json`
- [ ] Verify permissions are merged correctly (existing settings preserved)
- [ ] Run full `mac_setup.sh` to verify integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)