### PR TITLE
Add '0. all' option to install/uninstall commands

### DIFF
--- a/.claude/commands/install.md
+++ b/.claude/commands/install.md
@@ -1,12 +1,13 @@
 Read the Brewfile at `~/.Brewfile` to get the full list of available software.
 
-Present the user with a formatted list of all available software, organized by category (CLI tools, Applications, Fonts, Shell, Config, etc.). Display the list inside a code block for consistent formatting. Include Oh My Zsh in the Shell category. Include "Claude Commands" in a Config category at the end.
+Present the user with a formatted list of all available software, organized by category (CLI tools, Applications, Fonts, Shell, Config, etc.). Display the list inside a code block for consistent formatting. Start with "0. all" option to install everything. Include Oh My Zsh in the Shell category. Include "Claude Commands" in a Config category at the end.
 
 Ask the user which ones they would like to install. They can select multiple items.
 
 Once they confirm their selection, install the selected software using the appropriate method:
-- For Homebrew packages: `brew install <package>`
-- For Homebrew casks: `brew install --cask <package>`
+- For "all" (option 0): Run `brew bundle --file=~/.Brewfile` to install all Homebrew packages, then install Oh My Zsh and Claude Commands
+- For individual Homebrew packages: `brew install <package>`
+- For individual Homebrew casks: `brew install --cask <package>`
 - For Oh My Zsh: `sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended`
 - For Claude Commands: Copy the command files from the Mac-Setup repo to `~/.claude/commands/` and copy the Brewfile to `~/.Brewfile`. If the repo is not available locally, inform the user they need to clone it first or run the full mac_setup.sh script.
 

--- a/.claude/commands/uninstall.md
+++ b/.claude/commands/uninstall.md
@@ -1,12 +1,13 @@
 Read the Brewfile at `~/.Brewfile` to get the full list of software that may have been installed by this setup.
 
-Present the user with a formatted list of all software, organized by category (CLI tools, Applications, Fonts, Shell, Config, etc.). Display the list inside a code block for consistent formatting. Include Oh My Zsh in the Shell category. Include "Claude Commands" in a Config category. Include "Homebrew" as an option at the end of the list.
+Present the user with a formatted list of all software, organized by category (CLI tools, Applications, Fonts, Shell, Config, etc.). Display the list inside a code block for consistent formatting. Start with "0. all" option to uninstall all Brewfile software. Include Oh My Zsh in the Shell category. Include "Claude Commands" in a Config category. Include "Homebrew" as an option at the end of the list.
 
 Ask the user which ones they would like to uninstall. They can select multiple items.
 
 Once they confirm their selection, uninstall the selected software using the appropriate method:
-- For Homebrew packages: `brew uninstall <package>`
-- For Homebrew casks: `brew uninstall --cask <package>`
+- For "all" (option 0): Run `brew bundle cleanup --force --file=~/.Brewfile` to uninstall all Brewfile software (does not uninstall Oh My Zsh, Claude Commands, or Homebrew itself)
+- For individual Homebrew packages: `brew uninstall <package>`
+- For individual Homebrew casks: `brew uninstall --cask <package>`
 - For Oh My Zsh: `sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/uninstall.sh)"`
 - For Claude Commands: Remove `~/.claude/commands/install.md`, `~/.claude/commands/uninstall.md`, `~/.claude/commands/update.md`, `~/.claude/commands/xcode.md`, and `~/.Brewfile`
 - For Homebrew itself: Follow the special Homebrew uninstall process below


### PR DESCRIPTION
## Summary
- Added "0. all" as the first option in the software list for both install and uninstall commands
- "all" option uses `brew bundle` instead of individual brew install/uninstall commands

## Changes
- `/install` - Uses `brew bundle --file=~/.Brewfile` when "all" is selected
- `/uninstall` - Uses `brew bundle cleanup --force --file=~/.Brewfile` when "all" is selected

## Test plan
- [ ] Run `/install all` and verify it uses brew bundle
- [ ] Run `/install` and verify "0. all" appears at the top of the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)