### PR TITLE
Add global Claude preferences with tag format convention

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,14 @@
+# Global Preferences
+
+These are my global preferences. Project-specific CLAUDE.md files can override these settings.
+
+## Git Tags
+
+Use semantic versioning without the 'v' prefix for tags:
+- Correct: `1.0.0`, `2.1.3`, `0.5.0-beta`
+- Incorrect: `v1.0.0`, `v2.1.3`
+
+When creating tags in a project:
+1. First check if the project's CLAUDE.md specifies a tag format
+2. If not, check existing release tags (`git tag -l`) to match the project's convention
+3. If no existing tags, use this global preference (no 'v' prefix)

--- a/Brewfile
+++ b/Brewfile
@@ -20,6 +20,7 @@ cask "proxyman"
 cask "claude"
 cask "db-browser-for-sqlite"
 cask "ssh-config-editor"
+cask "warp"
 
 # Fonts
 cask "font-jetbrains-mono"

--- a/claude_config_setup.sh
+++ b/claude_config_setup.sh
@@ -23,4 +23,12 @@ else
     echo "Claude settings installed to ~/.claude/settings.json"
 fi
 
+## Copy global CLAUDE.md (only if it doesn't exist to preserve user customizations)
+if [ ! -f ~/.claude/CLAUDE.md ]; then
+    cp "$SCRIPT_DIR/.claude/CLAUDE.md" ~/.claude/CLAUDE.md
+    echo "Global preferences installed to ~/.claude/CLAUDE.md"
+else
+    echo "Global preferences already exist at ~/.claude/CLAUDE.md (skipped)"
+fi
+
 echo "\nDone."


### PR DESCRIPTION
## Summary
- Added `~/.claude/CLAUDE.md` for global preferences that apply across all projects
- Establishes default tag format: semantic versioning without 'v' prefix (e.g., `1.0.0`)

## Tag Format Resolution Order
1. Check project's CLAUDE.md for explicit tag format
2. Check existing release tags (`git tag -l`) to match project convention
3. Fall back to global preference (no 'v' prefix)

## Changes
- `.claude/CLAUDE.md` - New global preferences file
- `claude_config_setup.sh` - Installs global preferences (skips if already exists)

## Test plan
- [ ] Run `./claude_config_setup.sh` on system without `~/.claude/CLAUDE.md`
- [ ] Run `./claude_config_setup.sh` on system with existing `~/.claude/CLAUDE.md` (should skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)