### PR TITLE
Update documentation with all current software and structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,17 +17,20 @@ Automates the installation and configuration of daily-use software and developme
 - `claude_config_setup.sh` - Installs Claude Code commands and settings
 - `.claude/commands/` - Claude Code commands (copied to `~/.claude/commands/` during setup)
 - `.claude/settings.json` - Claude Code permission settings (merged into `~/.claude/settings.json` during setup)
+- `.claude/CLAUDE.md` - Global preferences (copied to `~/.claude/CLAUDE.md` during setup)
 
 ## Installed Software
 
 ### CLI Tools
-- git, zsh, swift-format, swiftlint
+- git, gh (GitHub CLI), glab (GitLab CLI), jq
+- zsh, swift-format, swiftlint
 - xcodes (Xcode version manager)
 - zsh-autosuggestions, zsh-syntax-highlighting
 
 ### Applications
 - Setapp, Fork, Visual Studio Code, 1Password
 - RapidAPI, Proxyman, Claude, DB Browser for SQLite
+- SSH Config Editor, Warp
 
 ### Fonts
 - JetBrains Mono

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Automates the installation and configuration of daily-use software and developme
 ## What Gets Installed
 
 ### CLI Tools
-- git, zsh
-- swift-format, swiftlint
+- git, gh (GitHub CLI), glab (GitLab CLI)
+- jq (JSON processor)
+- zsh, swift-format, swiftlint
 - xcodes (Xcode version manager)
 - zsh-autosuggestions, zsh-syntax-highlighting
 
@@ -26,6 +27,8 @@ Automates the installation and configuration of daily-use software and developme
 - Proxyman
 - Claude
 - DB Browser for SQLite
+- SSH Config Editor
+- Warp (terminal)
 
 ### Fonts
 - JetBrains Mono
@@ -76,11 +79,15 @@ Mac-Setup/
 ├── oh_my_zsh_install.sh   # Installs Oh My Zsh
 ├── zshrc_alias_setup.sh   # Configures shell aliases
 ├── ssh_key_setup.sh       # Sets up SSH keys
-└── .claude/commands/      # Claude Code commands (copied to ~/.claude/commands/)
-    ├── install.md
-    ├── uninstall.md
-    ├── update.md
-    └── xcode.md
+├── claude_config_setup.sh # Installs Claude Code commands and settings
+└── .claude/
+    ├── CLAUDE.md          # Global preferences (copied to ~/.claude/CLAUDE.md)
+    ├── settings.json      # Permission settings (merged into ~/.claude/settings.json)
+    └── commands/          # Claude Code commands (copied to ~/.claude/commands/)
+        ├── install.md
+        ├── uninstall.md
+        ├── update.md
+        └── xcode.md
 ```
 
 ## Customization


### PR DESCRIPTION
## Summary
Updated README.md and CLAUDE.md to reflect all current software and project structure.

## Changes
- Added missing CLI tools: gh (GitHub CLI), glab (GitLab CLI), jq
- Added missing applications: SSH Config Editor, Warp
- Updated project structure to include:
  - `claude_config_setup.sh`
  - `.claude/CLAUDE.md`
  - `.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)