### PR TITLE
Add Proxyman MCP server to Claude Code setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,12 @@ These commands are installed globally to `~/.claude/commands/` during setup:
 
 Commands read from `~/.Brewfile` to determine available software.
 
+## MCP Servers
+
+Installed globally (user scope) during setup:
+
+- **Proxyman** - Network traffic inspection and debugging. Requires Proxyman with MCP enabled (Settings → MCP). Supports both Setapp and direct installs.
+
 ## Key Conventions
 
 - All scripts use `#!/bin/zsh`
@@ -101,6 +107,11 @@ xcodes list
 xcodes select:*
 xcodes version
 xcodes update
+
+# Claude Code configuration
+claude mcp add:*
+claude mcp remove:*
+claude plugin install:*
 
 # File operations for config installation
 cp:*

--- a/claude_config_setup.sh
+++ b/claude_config_setup.sh
@@ -59,8 +59,28 @@ if command -v claude &>/dev/null; then
 
     claude plugin install swift-concurrency@swift-concurrency-agent-skill 2>/dev/null && \
         echo "Installed swift-concurrency plugin" || echo "swift-concurrency already installed or unavailable"
+
+    # Install MCP servers
+    echo "\nInstalling Claude Code MCP servers..."
+
+    # Proxyman - network debugging (requires MCP enabled in Proxyman: Settings → MCP)
+    PROXYMAN_MCP=""
+    while IFS= read -r app_path; do
+        if [ -x "$app_path/Contents/MacOS/mcp-server" ]; then
+            PROXYMAN_MCP="$app_path/Contents/MacOS/mcp-server"
+            break
+        fi
+    done <<< "$(mdfind 'kMDItemFSName == "Proxyman.app"' 2>/dev/null)"
+
+    if [ -n "$PROXYMAN_MCP" ]; then
+        claude mcp add proxyman -s user -- "$PROXYMAN_MCP" 2>/dev/null && \
+            echo "Installed Proxyman MCP server ($PROXYMAN_MCP)" || echo "Proxyman MCP already configured"
+        echo "Note: Enable MCP in Proxyman → Settings → MCP if not already enabled"
+    else
+        echo "Proxyman with MCP support not found — install it via Setapp or https://proxyman.com"
+    fi
 else
-    echo "\nClaude CLI not found — skipping plugin installation."
+    echo "\nClaude CLI not found — skipping plugin and MCP installation."
     echo "Install Claude Code first, then re-run this script to install plugins."
 fi
 


### PR DESCRIPTION
## Summary

- Auto-detect Proxyman install location via `mdfind` (supports Setapp, direct, or custom installs)
- Configure Proxyman MCP server at user scope so it's available across all projects
- Skip gracefully if Proxyman isn't installed or lacks MCP support
- Document MCP servers section in CLAUDE.md
- Add `claude mcp`/`claude plugin` to allowed commands

## Notes

- Proxyman's MCP server requires the paid version (available via Setapp subscription)
- Users must enable MCP in Proxyman: Settings → MCP
- The Homebrew cask installs the free/trial version which does not include the MCP binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)